### PR TITLE
Automatically close when SSB server closes

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,13 @@ function BlobCSP() {
 }
 
 module.exports = function init(sbot, conf) {
-  http.createServer(ServeBlobs(sbot)).listen(PORT);
+  const server = http.createServer(ServeBlobs(sbot)).listen(PORT);
+
+  // Ensure that HTTP server is closed when the SSB server closes.
+  sbot.close.hook(function (fn, args) {
+    server.close()
+    fn.apply(this, args)
+  })
 };
 
 module.exports.init = module.exports;

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "mime-types": "2.1.17"
   },
   "devDependencies": {
-    "tape": "^4.5.1"
+    "ssb-blobs": "^1.2.2",
+    "ssb-server": "^15.2.0",
+    "tape": "^4.13.2"
   },
   "scripts": {
-    "test": ":"
+    "test": "node test"
   },
   "license": "MIT"
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,11 @@
+const tape = require('tape')
+
+const ssbServer = require('ssb-server')
+
+const server = ssbServer
+  .use(require('ssb-blobs'))
+  .use(require('./'))({ temp: true })
+
+tape('server exits', (t) => {
+  server.close(t.end)
+})


### PR DESCRIPTION
Problem: This plugin starts and HTTP server that never closes, so even
after closing the HTTP server the process never ends.

Solution: Add a hook that automatically closes the HTTP server when the
`close()` method is called on the SSB server. This is consistent with
the behavior found in SSB-WS.