### PR TITLE
Add unboxer when key is passed

### DIFF
--- a/id-to-url.js
+++ b/id-to-url.js
@@ -1,5 +1,10 @@
 const PORT = require('./port');
-module.exports = function idToUrl(blobId) {
+
+module.exports = function idToUrl(blobId, params) {
   const blobRef = encodeURIComponent(blobId);
-  return `http://localhost:${PORT}/${blobRef}`;
+  const paramsStr = (params && params.unbox)
+    ? `?unbox=${encodeURIComponent(params.unbox.toString('base64'))}`
+    : '';
+
+  return `http://localhost:${PORT}/${blobRef}${paramsStr}`;
 }

--- a/index.js
+++ b/index.js
@@ -2,17 +2,18 @@ var pull = require('pull-stream');
 var cat = require('pull-cat');
 var toPull = require('stream-to-pull-stream');
 var ident = require('pull-identify-filetype');
+var { createUnboxStream } = require('pull-box-stream');
 var mime = require('mime-types');
 var URL = require('url');
 var http = require('http');
 var PORT = require('./port');
-const { createUnboxStream } = require('pull-box-stream')
+
+const zeros = Buffer.alloc(24, 0);
 
 const createUnboxTransform = (queryParam) => {
   const keyBase64 = queryParam.slice(0, 44)
   const keyBytes = Buffer.from(keyBase64, 'base64')
-  const nonce = Buffer.alloc(24, 0);
-  return createUnboxStream(keyBytes, nonce);
+  return createUnboxStream(keyBytes, zeros);
 }
 
 function ServeBlobs(sbot) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "stream-to-pull-stream": "1.7.2"
   },
   "devDependencies": {
+    "pull-box-stream": "^1.0.13",
     "ssb-blobs": "^1.2.2",
     "ssb-server": "^15.2.0",
     "tape": "^4.13.2"

--- a/test.js
+++ b/test.js
@@ -1,11 +1,97 @@
-const tape = require('tape')
+const http = require("http");
+const pull = require("pull-stream");
+const ssbServer = require("ssb-server");
+const tape = require("tape");
+const { createBoxStream } = require("pull-box-stream");
+const crypto = require("crypto");
 
-const ssbServer = require('ssb-server')
+const toUrl = require("./id-to-url");
 
-const server = ssbServer
-  .use(require('ssb-blobs'))
-  .use(require('./'))({ temp: true })
+const server = ssbServer.use(require("ssb-blobs")).use(require("./"))({
+  temp: true,
+});
 
-tape('server exits', (t) => {
-  server.close(t.end)
-})
+tape("blobs are accessible", (t) => {
+  const original = "hello world";
+
+  t.plan(2);
+  pull(
+    pull.values([original]),
+    server.blobs.add((err, val) => {
+      t.error(err);
+      http
+        .get(toUrl(val), (res) => {
+          const data = [];
+          res
+            .on("data", (chunk) => data.push(chunk))
+            .on("end", () =>
+              // Ensure that the blob matches this file's contents exactly.
+              t.equals(
+                data.join(""),
+                original,
+                "blob upload matches original file"
+              )
+            );
+        })
+        .on("error", t.error)
+        .end();
+    })
+  );
+});
+
+const encrypt = async (input) => {
+  const key = crypto.createHash("sha256").update(input).digest();
+  const nonce = Buffer.alloc(24, 0);
+
+  return new Promise((resolve, reject) => {
+    pull(
+      pull.values([input]),
+      createBoxStream(key, nonce),
+      pull.collect((err, data) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({
+            key,
+            data,
+          });
+        }
+      })
+    );
+  });
+};
+
+tape("encrypted blobs are accessible", async (t) => {
+  t.plan(2);
+  const original = "hello world";
+  const { key, data } = await encrypt(original);
+
+  pull(
+    pull.values(data),
+    server.blobs.add((err, val) => {
+      const encodedKey = encodeURIComponent(key.toString("base64"));
+      const url = `${toUrl(val)}?unbox=${encodedKey}.boxs`;
+      t.error(err);
+      http
+        .get(url, (res) => {
+          const data = [];
+          res
+            .on("data", (chunk) => data.push(chunk))
+            .on("end", () =>
+              // Ensure that the blob matches this file's contents exactly.
+              t.equals(
+                data.join(""),
+                original,
+                "blob upload matches original file"
+              )
+            );
+        })
+        .on("error", t.error)
+        .end();
+    })
+  );
+});
+
+tape("server exits", (t) => {
+  server.close(t.end);
+});

--- a/test.js
+++ b/test.js
@@ -68,10 +68,10 @@ tape("encrypted blobs are accessible", async (t) => {
 
   pull(
     pull.values(data),
-    server.blobs.add((err, val) => {
-      const encodedKey = encodeURIComponent(key.toString("base64"));
-      const url = `${toUrl(val)}?unbox=${encodedKey}.boxs`;
+    server.blobs.add((err, id) => {
       t.error(err);
+
+      const url = toUrl(id, { unbox: key });
       http
         .get(url, (res) => {
           const data = [];


### PR DESCRIPTION
Problem: Encrypted blobs aren't being unboxed with the `?unbox=` query
parameter, which means that this problem is kicked down the road to the
application to manually unbox all blobs. This is a pain point when using
plain old `<img>` elements.

Solution: Copy the behavior from SSB-WS so that `?unbox=` query
parameters are used as unbox keys and decrypted before being passed
along. These modules solve many of the same problems, but the deep
Multiserver integration in SSB-WS makes it difficult to know which port
the server is running on. There's also Multiblob-HTTP, which seems to
have very similar behavior to SSB-Serve-Blobs, but it *also* doesn't
implement unboxing. Someday maybe these modules should be consolidated,
but for the time being I think change is a move in the right direction.