### PR TITLE
allow custom port in id-to-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ console.log(toUrl(blobId));
 
 console.log(toUrl(blobId, { unbox: unboxKey }));
 // http://localhost:26835/%26d8kM9RXf5zvvy%2BAzlQ%2F%2FJbCF0AEJelTl6m03u3dVVj4%3D.sha256?unbox=uU0nuZNNPgilLlLX2n2r%2BsSE7%2BN6U4DukIj3rOLvzek%3D
+
+console.log(toUrl(blobId, { port: 6000 }));
+// http://localhost:6000/%26d8kM9RXf5zvvy%2BAzlQ%2F%2FJbCF0AEJelTl6m03u3dVVj4%3D.sha256
 ```
 
 ```js

--- a/id-to-url.js
+++ b/id-to-url.js
@@ -1,10 +1,11 @@
-const PORT = require('./port');
+var DEFAULT_PORT = require('./port');
 
 module.exports = function idToUrl(blobId, params) {
+  const port = (params && params.port) || DEFAULT_PORT;
   const blobRef = encodeURIComponent(blobId);
   const paramsStr = (params && params.unbox)
     ? `?unbox=${encodeURIComponent(params.unbox.toString('base64'))}`
     : '';
 
-  return `http://localhost:${PORT}/${blobRef}${paramsStr}`;
+  return `http://localhost:${port}/${blobRef}${paramsStr}`;
 }

--- a/test.js
+++ b/test.js
@@ -6,10 +6,14 @@ const { createBoxStream } = require("pull-box-stream");
 const crypto = require("crypto");
 
 const toUrl = require("./id-to-url");
+const port = 10000 + Math.floor(Math.random() * 9000)
 
-const server = ssbServer.use(require("ssb-blobs")).use(require("./"))({
-  temp: true,
-});
+const server = ssbServer
+  .use(require("ssb-blobs"))
+  .use(require("./"))({
+    temp: true,
+    serveBlobs: { port }
+  });
 
 tape("blobs are accessible", (t) => {
   const original = "hello world";
@@ -20,7 +24,7 @@ tape("blobs are accessible", (t) => {
     server.blobs.add((err, val) => {
       t.error(err);
       http
-        .get(toUrl(val), (res) => {
+        .get(toUrl(val, { port }), (res) => {
           const data = [];
           res
             .on("data", (chunk) => data.push(chunk))
@@ -71,7 +75,7 @@ tape("encrypted blobs are accessible", async (t) => {
     server.blobs.add((err, id) => {
       t.error(err);
 
-      const url = toUrl(id, { unbox: key });
+      const url = toUrl(id, { unbox: key, port });
       http
         .get(url, (res) => {
           const data = [];


### PR DESCRIPTION
Hit a problem where I was using a custom port (to avoid colliding with patchbay) but noticed that id-to-port did not care about the port config!

so this fixes that. I've also changed the tests so they run on a random port. This is similarly to avoid colliding with other running instances sitting on the default port