### PR TITLE
add support for custom hostname to id-to-url

### DIFF
--- a/id-to-url.js
+++ b/id-to-url.js
@@ -7,7 +7,7 @@ module.exports = function idToUrl(blobId, params) {
 
   const [pureBlobId, query] = blobId.split('?');
 
-  if (params && params.hostname) url.hostname = params.hostname;
+  if (params?.hostname) url.hostname = params.hostname;
   if (params?.port) url.port = params.port;
 
   url.pathname = `/get/${encodeURIComponent(pureBlobId)}`;

--- a/id-to-url.js
+++ b/id-to-url.js
@@ -31,7 +31,7 @@ function extractKey (query) {
 
 function toString (key) {
   if (typeof key === 'string') return key
-  if (Buffer.isBuffer) return key.toString('base64')
+  if (Buffer.isBuffer(key)) return key.toString('base64')
 
   throw new Error('cannot coerce toString, unknown type: ' + typeof key)
 }

--- a/id-to-url.js
+++ b/id-to-url.js
@@ -8,7 +8,7 @@ module.exports = function idToUrl(blobId, params) {
   const [pureBlobId, query] = blobId.split('?');
 
   if (params && params.hostname) url.hostname = params.hostname;
-  if (params && params.port) url.port = params.port;
+  if (params?.port) url.port = params.port;
 
   url.pathname = `/get/${encodeURIComponent(pureBlobId)}`;
 

--- a/id-to-url.js
+++ b/id-to-url.js
@@ -12,7 +12,7 @@ module.exports = function idToUrl(blobId, params) {
 
   url.pathname = `/get/${encodeURIComponent(pureBlobId)}`;
 
-  const unbox = extractKey(query) || (params && params.unbox && toString(params.unbox));
+  const unbox = extractKey(query) ?? (params?.unbox && toString(params.unbox));
   if (unbox) url.searchParams.set('unbox', unbox + '.boxs');
 
   return url.href

--- a/test/id-to-url.test.js
+++ b/test/id-to-url.test.js
@@ -1,0 +1,42 @@
+const test = require('tape');
+const toUrl = require('../id-to-url');
+
+
+test('id-to-url', t => {
+
+  const blobId = '&bt/HJeVcY6OZb4Nb21yMSDKH2ZW+otEe535CCCPfXug=.sha256';
+  const unbox = 'uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=';
+  const blobIdWithQuery = `${blobId}?unbox=${unbox}`;
+
+  t.equal(
+    toUrl(blobId),
+    'http://localhost:26835/get/%26bt%2FHJeVcY6OZb4Nb21yMSDKH2ZW%2BotEe535CCCPfXug%3D.sha256',
+    'basic'
+  )
+
+  t.equal(
+    toUrl(blobId, { port: 1234 }),
+    'http://localhost:1234/get/%26bt%2FHJeVcY6OZb4Nb21yMSDKH2ZW%2BotEe535CCCPfXug%3D.sha256',
+    'params.port'
+  )
+
+  t.equal(
+    toUrl(blobId, { hostname: 'blobs.com' }),
+    'http://blobs.com:26835/get/%26bt%2FHJeVcY6OZb4Nb21yMSDKH2ZW%2BotEe535CCCPfXug%3D.sha256',
+    'params.hostname'
+  )
+
+  t.equal(
+    toUrl(blobId, { unbox }),
+    'http://localhost:26835/get/%26bt%2FHJeVcY6OZb4Nb21yMSDKH2ZW%2BotEe535CCCPfXug%3D.sha256?unbox=uU0nuZNNPgilLlLX2n2r%2BsSE7%2BN6U4DukIj3rOLvzek%3D.boxs',
+    'params.unbox'
+  )
+
+  t.equal(
+    toUrl(blobIdWithQuery),
+    'http://localhost:26835/get/%26bt%2FHJeVcY6OZb4Nb21yMSDKH2ZW%2BotEe535CCCPfXug%3D.sha256?unbox=uU0nuZNNPgilLlLX2n2r%2BsSE7%2BN6U4DukIj3rOLvzek%3D.boxs',
+    'id with unbox query'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
adds support for `params.hostname`

I wrote some tests and surfaced a broken edgecase where blobIds of form `<blobId>?unbox=<unboxKey>` were failing to be URI encoded (the `<unboxKey>` part)

So I refactored to use URL tools to make this more stable